### PR TITLE
cli: Fix get-program-accounts encoding

### DIFF
--- a/clients/cli/src/client.rs
+++ b/clients/cli/src/client.rs
@@ -5,7 +5,7 @@ use {
         client_error::ClientError,
         rpc_client::RpcClient,
         rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
-        rpc_filter::{Memcmp, RpcFilterType},
+        rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
     },
     solana_program::{
         borsh1::try_from_slice_unchecked, hash::Hash, instruction::Instruction, message::Message,
@@ -90,9 +90,9 @@ pub(crate) fn get_stake_pools(
             &spl_stake_pool::id(),
             RpcProgramAccountsConfig {
                 // 0 is the account type
-                filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+                filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new(
                     0,
-                    vec![1],
+                    MemcmpEncodedBytes::Base58("2".to_string()),
                 ))]),
                 account_config: RpcAccountInfoConfig {
                     encoding: Some(UiAccountEncoding::Base64),


### PR DESCRIPTION
#### Problem

The `getProgramAccounts` call used during `list-all` fails for certain RPCs, giving a 400 bad request.

#### Summary of changes

Replace the filter with a base58 encoded version. Separately, we'll need to see what's wrong with the bytes version, but this will at least unblock users.