### PR TITLE
dependabot: Add js-legacy and python clients

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,16 @@ updates:
     timezone: UTC
   open-pull-requests-limit: 6
 - package-ecosystem: npm
-  directory: "/"
+  directories:
+    - "/"
+    - "/clients/js-legacy"
+  schedule:
+    interval: daily
+    time: "09:00"
+    timezone: UTC
+  open-pull-requests-limit: 6
+- package-ecosystem: pip
+  directory: "/clients/py"
   schedule:
     interval: daily
     time: "09:00"


### PR DESCRIPTION
#### Problem

The dependabot config on the repo only looks at the top-level lockfile, which means that the js-legacy client isn't updated.

#### Summary of changes

Add the js-legacy client to the dependabot config. At the same time, add the python client.