### PR TITLE
package.json: Add publish rust script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "template:upgrade": "zx ./scripts/upgrade-template.mjs",
     "rust:spellcheck": "cargo spellcheck --code 1",
     "rust:audit": "zx ./scripts/rust/audit.mjs",
-    "rust:semver": "cargo semver-checks"
+    "rust:semver": "cargo semver-checks",
+    "rust:publish": "zx ./scripts/rust/publish.mjs"
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",


### PR DESCRIPTION
#### Problem

The publish step failed because there's no `rust:publish` script in the top-level package.json.

#### Summary of changes

Add the step