### PR TITLE
cli: Properly support token-2022 mints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7152,6 +7152,7 @@ dependencies = [
  "spl-associated-token-account-client",
  "spl-stake-pool",
  "spl-token 8.0.0",
+ "spl-token-2022 7.0.0",
 ]
 
 [[package]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -33,6 +33,9 @@ spl-stake-pool = { version = "=2.0.1", path = "../../program", features = [
 spl-token = { version = "=8.0", features = [
   "no-entrypoint",
 ] }
+spl-token-2022 = { version = "=7.0", features = [
+  "no-entrypoint",
+] }
 bs58 = "0.5.1"
 bincode = "1.3.1"
 

--- a/clients/cli/scripts/setup-stake-pool-token-2022.sh
+++ b/clients/cli/scripts/setup-stake-pool-token-2022.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Script to setup a stake pool from scratch.  Please modify the parameters to
+# create a stake pool to your liking!
+
+cd "$(dirname "$0")" || exit
+command_args=()
+sol_amount=$1
+
+###################################################
+### MODIFY PARAMETERS BELOW THIS LINE FOR YOUR POOL
+###################################################
+
+# Epoch fee, assessed as a percentage of rewards earned by the pool every epoch,
+# represented as `numerator / denominator`
+command_args+=( --epoch-fee-numerator 1 )
+command_args+=( --epoch-fee-denominator 100 )
+
+# Withdrawal fee for SOL and stake accounts, represented as `numerator / denominator`
+command_args+=( --withdrawal-fee-numerator 2 )
+command_args+=( --withdrawal-fee-denominator 100 )
+
+# Deposit fee for SOL and stake accounts, represented as `numerator / denominator`
+command_args+=( --deposit-fee-numerator 3 )
+command_args+=( --deposit-fee-denominator 100 )
+
+command_args+=( --referral-fee 0 ) # Percentage of deposit fee that goes towards the referrer (a number between 0 and 100, inclusive)
+
+command_args+=( --max-validators 2350 ) # Maximum number of validators in the stake pool, 2350 is the current maximum possible
+
+# (Optional) Deposit authority, required to sign all deposits into the pool.
+# Setting this variable makes the pool "private" or "restricted".
+# Uncomment and set to a valid keypair if you want the pool to be restricted.
+#command_args+=( --deposit-authority keys/authority.json )
+
+###################################################
+### MODIFY PARAMETERS ABOVE THIS LINE FOR YOUR POOL
+###################################################
+
+keys_dir=keys
+spl_stake_pool=spl-stake-pool
+# Uncomment to use a local build
+spl_stake_pool=../../../target/debug/spl-stake-pool
+
+mkdir -p $keys_dir
+
+create_keypair () {
+  if test ! -f "$1"
+  then
+    solana-keygen new --no-passphrase -s -o "$1"
+  fi
+}
+
+echo "Creating pool"
+stake_pool_keyfile=$keys_dir/stake-pool.json
+validator_list_keyfile=$keys_dir/validator-list.json
+mint_keyfile=$keys_dir/mint.json
+reserve_keyfile=$keys_dir/reserve.json
+create_keypair $stake_pool_keyfile
+create_keypair $validator_list_keyfile
+create_keypair $mint_keyfile
+create_keypair $reserve_keyfile
+
+spl-token create-token --program-2022 "$mint_keyfile"
+
+set -ex
+$spl_stake_pool \
+  create-pool \
+  "${command_args[@]}" \
+  --pool-keypair "$stake_pool_keyfile" \
+  --validator-list-keypair "$validator_list_keyfile" \
+  --mint-keypair "$mint_keyfile" \
+  --reserve-keypair "$reserve_keyfile"
+
+set +ex
+stake_pool_pubkey=$(solana-keygen pubkey "$stake_pool_keyfile")
+set -ex
+
+echo "Depositing SOL into stake pool"
+$spl_stake_pool deposit-sol "$stake_pool_pubkey" "$sol_amount"


### PR DESCRIPTION
#### Problem

Although the stake pool program allows for mints on token-2022, the CLI still does not.

#### Summary of changes

A few changes:

* use spl-token-2022 for instruction creators
* allow for the token program id to be spl_token::id() or spl_token_2022::id()
* derive ATAs with the token program id
* use the token program id stored on the stake pool
* during pool creation, return a helpful error if the mint is configured incorrectly
* add a test script using token-2022