### PR TITLE
py: Bump dev deps all together, as required

### DIFF
--- a/clients/py/optional-requirements.txt
+++ b/clients/py/optional-requirements.txt
@@ -1,11 +1,11 @@
-flake8==7.1.2
+flake8==7.2.0
 iniconfig==2.1.0
 mccabe==0.7.0
 mypy==1.15.0
 mypy-extensions==1.0.0
 packaging==24.2
 pluggy==1.5.0
-pycodestyle==2.12.1
-pyflakes==3.2.0
+pycodestyle==2.13.0
+pyflakes==3.3.2
 pytest==8.3.5
 pytest-asyncio==0.26.0


### PR DESCRIPTION
#### Problem

There are new versions of the python dev deps, but the individual bump PRs are failing because they have to go out together.

#### Summary of changes

Bump them all at once.