### PR TITLE
CI: Fix installing cargo-release

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -88,9 +88,7 @@ jobs:
           cargo-cache-fallback-key: cargo-publish
 
       - name: Install Cargo Release
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-release
+        run: which cargo-release || cargo install cargo-release@0.25.17
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -88,7 +88,9 @@ jobs:
           cargo-cache-fallback-key: cargo-publish
 
       - name: Install Cargo Release
-        run: which cargo-release || cargo install cargo-release
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-release
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:


### PR DESCRIPTION
#### Problem

The publish rust job is failing because the rust version in the repo is too old: https://github.com/solana-program/stake-pool/actions/runs/15848005986/job/44675022510

#### Summary of changes

~I believe this works in other repos -- use the install action, which doesn't necessarily build from source.~

Pin version to 0.25.17