### PR TITLE
CI: Make dependabot approvals manual

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,8 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'solana-program'
+    #if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'solana-program'
+    if: false
     steps:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
#### Problem

Dependabot is merging a lot of changes, especially in the python clients, and we should examine those by hand first.

#### Summary of changes

Don't run the auto approve job, do it manually.