### PR TITLE
feat: add some missing tests that were already planned via // TODO

### DIFF
--- a/program/tests/helpers/mod.rs
+++ b/program/tests/helpers/mod.rs
@@ -2676,20 +2676,23 @@ pub async fn set_validator_list_to_uninitialized_account(
     let rent = context.banks_client.get_rent().await.unwrap();
     let account_size = std::mem::size_of::<state::ValidatorList>();
     let minimum_balance = rent.minimum_balance(account_size);
-    
+
     // Create an uninitialized account at the SAME validator list address
     // This simulates the validator list account being corrupted/uninitialized
     // while keeping the same pubkey that the stake pool expects
     let uninitialized_account = solana_sdk::account::Account {
         lamports: minimum_balance,
         data: vec![0u8; account_size], // All zeros - truly uninitialized
-        owner: id(), // Owned by stake pool program
+        owner: id(),                   // Owned by stake pool program
         executable: false,
         rent_epoch: 0,
     };
-    
+
     // Set the uninitialized account at the original validator list address
-    context.set_account(&stake_pool_accounts.validator_list.pubkey(), &uninitialized_account.into());
+    context.set_account(
+        &stake_pool_accounts.validator_list.pubkey(),
+        &uninitialized_account.into(),
+    );
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]


### PR DESCRIPTION
## Adds missing tests to increase test coverage

Closes #469 

- adds 4 missing tests
- adds a test helper for simulating an uninitialized validator list account
- adds a new setup facility 

This pull request adds new helper functionality and expands the test suite for stake pool validator management, focusing on error scenarios involving stake pool state and validator list account initialization. The main improvements include a new helper for simulating an uninitialized validator list account, new setup utilities for tests requiring epoch warping, and the implementation of previously stubbed error-handling tests for both adding and removing validators.

**Helpers and Setup Improvements:**

* Added `set_validator_list_to_uninitialized_account` helper in `mod.rs` to simulate an uninitialized validator list account for more robust error testing.
* Introduced `setup_with_context` in `vsa_add.rs` to provide a `ProgramTestContext` for tests requiring epoch warping, improving test flexibility and reliability.

**Expanded Error-Handling Tests:**

* Implemented `fail_with_not_updated_stake_pool` in both `vsa_add.rs` and `vsa_remove.rs` to verify correct error handling when attempting validator operations on an outdated stake pool. [[1]](diffhunk://#diff-293f4fd9fd181bde78b20f456799347e6eab6d8459c08697d44396b6ab3a597bL506-R603) [[2]](diffhunk://#diff-1c843fff88d063de1495e856d0c71e59a6659fe4b11b0b00d6f4f1a116f21dd9L844-R907)
* Implemented `fail_with_uninitialized_validator_list_account` in both `vsa_add.rs` and `vsa_remove.rs` to ensure the program returns the expected error when the validator list account is uninitialized. [[1]](diffhunk://#diff-293f4fd9fd181bde78b20f456799347e6eab6d8459c08697d44396b6ab3a597bL506-R603) [[2]](diffhunk://#diff-1c843fff88d063de1495e856d0c71e59a6659fe4b11b0b00d6f4f1a116f21dd9L844-R907)

**Test Imports and Usability:**

* Updated imports in `vsa_remove.rs` to include the new helper, ensuring all tests have access to the uninitialized account simulation.