### PR TITLE
CLI: Allow multiple vote accounts

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -2618,7 +2618,7 @@ fn main() {
                     .takes_value(true)
                     .required(true)
                     .multiple(true)
-                    .help("Vote account for the validator to increase stake to"),
+                    .help("Vote account(s) for the validator to increase stake to"),
             )
             .arg(
                 Arg::with_name("amount")
@@ -2627,7 +2627,7 @@ fn main() {
                     .value_name("AMOUNT")
                     .takes_value(true)
                     .multiple(true)
-                    .help("Amount in SOL to add to the validator stake account. Must be at least the rent-exempt amount for a stake plus 1 SOL for merging."),
+                    .help("Amount(s) in SOL to add to the validator stake account. Must be at least the rent-exempt amount for a stake plus 1 SOL for merging."),
             )
         )
         .subcommand(SubCommand::with_name("decrease-validator-stake")


### PR DESCRIPTION
- Modified `increase-validator-stake` to accept multiple vote_account and amount arguments

```bash
 cargo r --bin spl-stake-pool -- \
    --program-id DPoo15wWDqpPJJtS2MUZ49aRxqz5ZaaJCJP4z8bLuib \
    --url ~~~ \
    increase-validator-stake 
    --pool JitoY5pcAxWX6iyP2QdFwTznGb8A99PRCUCVVxB46WZ \
    --vote-account 23AoPQc3EPkfLWb14cKiWNahh1H9rtb3UBk8gWseohjF \
    --vote-account i7NyKBMJCA9bLM2nsGyAGCKHECuR2L5eh4GqFciuwNT 
    --amount 5 \
    --amount 5
```