### PR TITLE
CLI: Display validator index in stake pool list output

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -1418,7 +1418,8 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
     let cli_stake_pool_stake_account_infos = validator_list
         .validators
         .iter()
-        .map(|validator| {
+        .enumerate()
+        .map(|(index, validator)| {
             let validator_seed = NonZeroU32::new(validator.validator_seed_suffix.into());
             let (stake_account_address, _) = find_stake_program_address(
                 &config.stake_pool_program_id,
@@ -1434,6 +1435,7 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
             );
             let update_required = u64::from(validator.last_update_epoch) != epoch_info.epoch;
             CliStakePoolStakeAccountInfo {
+                index,
                 vote_account_address: validator.vote_account_address.to_string(),
                 stake_account_address: stake_account_address.to_string(),
                 validator_active_stake_lamports: validator.active_stake_lamports.into(),

--- a/clients/cli/src/output.rs
+++ b/clients/cli/src/output.rs
@@ -305,7 +305,8 @@ impl VerboseDisplay for CliStakePoolDetails {
         for stake_account in &self.stake_accounts {
             writeln!(
                 w,
-                "Vote Account: {}\tStake Account: {}\tActive Balance: {}\tTransient Stake Account: {}\tTransient Balance: {}\tLast Update Epoch: {}{}",
+                "Index: {}\tVote Account: {}\tStake Account: {}\tActive Balance: {}\tTransient Stake Account: {}\tTransient Balance: {}\tLast Update Epoch: {}{}",
+                stake_account.index,
                 stake_account.vote_account_address,
                 stake_account.stake_account_address,
                 Sol(stake_account.validator_active_stake_lamports),
@@ -347,6 +348,7 @@ impl VerboseDisplay for CliStakePoolDetails {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CliStakePoolStakeAccountInfo {
+    pub index: usize,
     pub vote_account_address: String,
     pub stake_account_address: String,
     pub validator_active_stake_lamports: u64,


### PR DESCRIPTION
#### Changes

- Add validator index to the stake pool list output 

#### Motivation

- Quickly identifying validator positions within the pool


```bash
...
Index: 1171     Vote Account: 5sWyespHdRiDbAGoxj4Y44LsZp4GkzGvQvZEwv8KE8gi      Stake Account: GWEWBtVuA7P8FLQPCTwKrMh46YjsfP1BdV5ukVF6kpRk     Active Balance: ◎0.003282880    Transient Stake Account: 7ztDwxykZLVtFfMesK7ya1n5r82xE7eyFJv7BXwVjBte   Transient Balance: ◎0.000000000 Last Update Epoch: 888
Total Pool Stake: ◎3494.310870999
Total Pool Tokens: 3166.971847939
Current Number of Validators: 1172
Max Number of Validators: 10000
```