### PR TITLE
program: update solana-security-txt

### DIFF
--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -30,13 +30,12 @@ security_txt! {
     // Required fields
     name: "SPL Stake Pool",
     project_url: "https://www.solana-program.com/docs/stake-pool",
-    contacts: "link:https://github.com/solana-program/stake-pool/security/advisories/new,mailto:security@anza.xyz,discord:https://solana.com/discord",
+    contacts: "link:https://github.com/solana-program/stake-pool/security/advisories/new,email:security@anza.xyz,discord:https://solana.com/discord",
     policy: "https://github.com/solana-program/stake-pool/blob/master/SECURITY.md",
 
     // Optional Fields
     preferred_languages: "en",
     source_code: "https://github.com/solana-program/stake-pool",
-    source_revision: "0e562954cc280185fcc87ef01d7bbc78859fdae9",
-    source_release: "program@v2.0.4",
+    source_release: concat!("program@v", env!("CARGO_PKG_VERSION")),
     auditors: "https://github.com/anza-xyz/security-audits#stake-pool"
 }


### PR DESCRIPTION
as i discovered doing https://github.com/solana-program/stake/pull/360 `mailto` is a syntax error:

```
query-security-txt ../target/deploy/spl_stake_pool.so
Error:
   0: Invalid contact `mailto:security@anza.xyz`

Location:
   /home/hana/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/query-security-txt-1.1.2/src/main.rs:35
```

i was going to leave the release/commit fields alone thinking this repo had its own style but i believe the hardcoded approach is fundamentally incorrect

it is possible, albeit an easy thing to overlook, to set up the github tag string _in advance_ of a github release. its not possible for a github tag done _after_ a release to be right, and its impossible for a hardcoded commit string to _ever_ be right (unless you want to play with quine stuff), because we care about what these values are _as of_ the github tagged commit. we deploy builds based on the tagged commits so by fixing metadata separately we just end up deploying binaries with the wrong values