### PR TITLE
program: Use saturating math for reserve accounting

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2218,10 +2218,11 @@ impl Processor {
         let previous_pool_token_supply = stake_pool.pool_token_supply;
         let reserve_rent = rent.minimum_balance(reserve_stake_info.data_len());
 
+        // Use `saturating_sub` here in case rent goes up and the reserve doesn't
+        // have enough lamports to cover rent.
         let mut total_lamports = reserve_stake_info
             .lamports()
-            .checked_sub(minimum_reserve_lamports(reserve_rent))
-            .ok_or(StakePoolError::CalculationFailure)?;
+            .saturating_sub(minimum_reserve_lamports(reserve_rent));
 
         for validator_stake_record in validator_list
             .deserialize_slice::<ValidatorStakeInfo>(0, validator_list.len() as usize)?


### PR DESCRIPTION
#### Problem

The program currently uses checked math on the reserve stake account to figure out how many lamports are part of the pool.

If rent is lowered, and then a new stake pool is created, and then rent is increased again, the checked math will fail since the reserve may not have enough lamports for the new rent-exempt amount.

#### Summary of changes

As a simple fix, use saturating math.

This change means that the total amount of lamports managed by the pool can be slightly incorrect if rent is increased, but there will only be a small impact on accounting, that doesn't materially impact pool token valuation.

All other stakes will be covered by adjusting delegations during a rent increase event, so this is the only case that can return an error.