### PR TITLE
program: Fix fee check

### DIFF
--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -969,11 +969,11 @@ impl Fee {
         // overflow
         if (old_num as u128)
             .checked_mul(self.denominator as u128)
-            .map(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.numerator as u128))
+            .and_then(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.numerator as u128))
             .ok_or(StakePoolError::CalculationFailure)?
             < (self.numerator as u128)
                 .checked_mul(old_denom as u128)
-                .map(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.denominator as u128))
+                .and_then(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.denominator as u128))
                 .ok_or(StakePoolError::CalculationFailure)?
         {
             msg!(
@@ -1457,5 +1457,21 @@ mod test {
 
         let withdraw_result = stake_pool.calc_lamports_withdraw_amount(1).unwrap();
         assert_eq!(stake_pool.total_lamports, withdraw_result);
+    }
+
+    #[test]
+    fn check_withdrawal_fee_overflow_failure() {
+        let old_fee = Fee {
+            numerator: 1,
+            denominator: u64::MAX,
+        };
+        let new_fee = Fee {
+            numerator: u64::MAX,
+            denominator: u64::MAX,
+        };
+        assert_eq!(
+            StakePoolError::CalculationFailure,
+            new_fee.check_withdrawal(&old_fee).unwrap_err()
+        );
     }
 }


### PR DESCRIPTION
#### Problem

The fee check is using `map` instead of `and_then`, allowing for an incorrect comparison between `Option::Some(...)` and `Option::None`.

#### Summary of changes

Use `and_then` instead to compare numbers instead of options.

This fix was included in the most recent deployment of the stake pool program, part of https://github.com/solana-program/stake-pool/releases/tag/program%40v2.1.0, and now it's time to re-integrate it into the main branch.