### PR TITLE
program: Cap increase to 50 basis points

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -40,9 +40,16 @@ pub const MAX_VALIDATORS_TO_UPDATE: usize = 4;
 /// Maximum factor by which a withdrawal fee can be increased per epoch
 /// protecting stakers from malicious users.
 /// If current fee is 0, `WITHDRAWAL_BASELINE_FEE` is used as the baseline
-pub const MAX_WITHDRAWAL_FEE_INCREASE: Fee = Fee {
+pub const MAX_WITHDRAWAL_FEE_INCREASE_FACTOR: Fee = Fee {
     numerator: 3,
     denominator: 2,
+};
+/// Maximum amount by which a withdrawal fee can be increased per epoch
+/// protecting stakers from malicious users.
+/// If current fee is 0, `WITHDRAWAL_BASELINE_FEE` is used as the baseline
+pub const MAX_WITHDRAWAL_FEE_INCREASE: Fee = Fee {
+    numerator: 1,
+    denominator: 200,
 };
 /// Drop-in baseline fee when evaluating withdrawal fee increases when fee is 0
 pub const WITHDRAWAL_BASELINE_FEE: Fee = Fee {

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         big_vec::BigVec, error::StakePoolError, MAX_WITHDRAWAL_FEE_INCREASE,
-        WITHDRAWAL_BASELINE_FEE,
+        MAX_WITHDRAWAL_FEE_INCREASE_FACTOR, WITHDRAWAL_BASELINE_FEE,
     },
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     bytemuck::{Pod, Zeroable},
@@ -953,7 +953,7 @@ impl Fee {
     /// if those are met, returning an error if not.
     pub fn check_withdrawal(&self, old_withdrawal_fee: &Fee) -> Result<(), StakePoolError> {
         // If the previous withdrawal fee was 0, we allow the fee to be set to a
-        // maximum of (WITHDRAWAL_BASELINE_FEE * MAX_WITHDRAWAL_FEE_INCREASE)
+        // WITHDRAWAL_BASELINE_FEE * MAX_WITHDRAWAL_FEE_INCREASE_FACTOR
         let (old_num, old_denom) =
             if old_withdrawal_fee.denominator == 0 || old_withdrawal_fee.numerator == 0 {
                 (
@@ -964,16 +964,42 @@ impl Fee {
                 (old_withdrawal_fee.numerator, old_withdrawal_fee.denominator)
             };
 
-        // Check that new_fee / old_fee <= MAX_WITHDRAWAL_FEE_INCREASE
+        // Check that new_fee - old_fee <= MAX_WITHDRAWAL_FEE_INCREASE
+        // Program fails if provided numerator or denominator is too large, resulting in
+        // overflow
+        if (old_denom as u128)
+            .checked_mul(self.denominator as u128)
+            .and_then(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.numerator as u128))
+            .ok_or(StakePoolError::CalculationFailure)?
+            < ((self.numerator as u128)
+                .checked_mul(old_denom as u128)
+                .ok_or(StakePoolError::CalculationFailure)?
+                .saturating_sub(
+                    (self.denominator as u128)
+                        .checked_mul(old_num as u128)
+                        .ok_or(StakePoolError::CalculationFailure)?,
+                )
+                .checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.denominator as u128)
+                .ok_or(StakePoolError::CalculationFailure)?)
+        {
+            msg!(
+                "Fee increase exceeds maximum allowed, need to increase by {} / {}",
+                MAX_WITHDRAWAL_FEE_INCREASE.numerator,
+                MAX_WITHDRAWAL_FEE_INCREASE.denominator,
+            );
+            return Err(StakePoolError::FeeIncreaseTooHigh);
+        }
+
+        // Check that new_fee / old_fee <= MAX_WITHDRAWAL_FEE_INCREASE_FACTOR
         // Program fails if provided numerator or denominator is too large, resulting in
         // overflow
         if (old_num as u128)
             .checked_mul(self.denominator as u128)
-            .and_then(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.numerator as u128))
+            .and_then(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE_FACTOR.numerator as u128))
             .ok_or(StakePoolError::CalculationFailure)?
             < (self.numerator as u128)
                 .checked_mul(old_denom as u128)
-                .and_then(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.denominator as u128))
+                .and_then(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE_FACTOR.denominator as u128))
                 .ok_or(StakePoolError::CalculationFailure)?
         {
             msg!(
@@ -1471,6 +1497,22 @@ mod test {
         };
         assert_eq!(
             StakePoolError::CalculationFailure,
+            new_fee.check_withdrawal(&old_fee).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn check_withdrawal_fee_max_increase() {
+        let old_fee = Fee {
+            numerator: 10,
+            denominator: 200,
+        };
+        let new_fee = Fee {
+            numerator: 11_000_000_000_000_001,
+            denominator: 200_000_000_000_000_000,
+        };
+        assert_eq!(
+            StakePoolError::FeeIncreaseTooHigh,
             new_fee.check_withdrawal(&old_fee).unwrap_err()
         );
     }

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -952,7 +952,7 @@ impl Fee {
     /// Withdrawal fees have some additional restrictions, this function checks
     /// if those are met, returning an error if not.
     pub fn check_withdrawal(&self, old_withdrawal_fee: &Fee) -> Result<(), StakePoolError> {
-        // If the previous withdrawal fee was 0, we allow the fee to be set to a
+        // If the previous withdrawal fee was 0, we allow the fee to be set to
         // WITHDRAWAL_BASELINE_FEE * MAX_WITHDRAWAL_FEE_INCREASE_FACTOR
         let (old_num, old_denom) =
             if old_withdrawal_fee.denominator == 0 || old_withdrawal_fee.numerator == 0 {


### PR DESCRIPTION
#### Problem

The program currently caps the withdrawal fee increase to 1.5x, which can be a lot at higher numbers.

#### Summary of changes

Also cap any increase to 50 basis points.

Note: this PR builds on top of #790, so should be merged afterwards. It is also included in the most recent release of the stake pool program on mainnet: https://github.com/solana-program/stake-pool/releases/tag/program%40v2.1.0