### PR TITLE
fix(js-legacy): correct account and lamports decoding in decodeDepositSol

### DIFF
--- a/clients/js-legacy/src/instructions.ts
+++ b/clients/js-legacy/src/instructions.ts
@@ -1093,20 +1093,24 @@ export class StakePoolInstruction {
     this.checkProgramId(instruction.programId);
     this.checkKeyLength(instruction.keys, 9);
 
-    const { amount } = decodeData(STAKE_POOL_INSTRUCTION_LAYOUTS.DepositSol, instruction.data);
+    const { lamports } = decodeData(STAKE_POOL_INSTRUCTION_LAYOUTS.DepositSol, instruction.data);
+
+    const keys = instruction.keys;
 
     return {
       programId: instruction.programId,
-      stakePool: instruction.keys[0].pubkey,
-      depositAuthority: instruction.keys[1].pubkey,
-      withdrawAuthority: instruction.keys[2].pubkey,
-      reserveStake: instruction.keys[3].pubkey,
-      fundingAccount: instruction.keys[4].pubkey,
-      destinationPoolAccount: instruction.keys[5].pubkey,
-      managerFeeAccount: instruction.keys[6].pubkey,
-      referralPoolAccount: instruction.keys[7].pubkey,
-      poolMint: instruction.keys[8].pubkey,
-      lamports: amount,
+      stakePool: keys[0].pubkey,
+      withdrawAuthority: keys[1].pubkey,
+      reserveStake: keys[2].pubkey,
+      fundingAccount: keys[3].pubkey,
+      destinationPoolAccount: keys[4].pubkey,
+      managerFeeAccount: keys[5].pubkey,
+      referralPoolAccount: keys[6].pubkey,
+      poolMint: keys[7].pubkey,
+      // keys[8] and keys[9] are the system and token programs. The optional
+      // deposit authority is appended after them by depositSol().
+      depositAuthority: keys.length > 10 ? keys[10].pubkey : undefined,
+      lamports,
     };
   }
 

--- a/clients/js-legacy/test/instructions.test.ts
+++ b/clients/js-legacy/test/instructions.test.ts
@@ -173,6 +173,43 @@ describe('StakePoolProgram', () => {
     expect(instruction2.keys[10].pubkey).toEqual(payload.depositAuthority);
   });
 
+  it('StakePoolInstruction.decodeDepositSol round-trips depositSol', () => {
+    const payload: DepositSolParams = {
+      programId: STAKE_POOL_PROGRAM_ID,
+      stakePool: stakePoolAddress,
+      withdrawAuthority: Keypair.generate().publicKey,
+      reserveStake: Keypair.generate().publicKey,
+      fundingAccount: Keypair.generate().publicKey,
+      destinationPoolAccount: Keypair.generate().publicKey,
+      managerFeeAccount: Keypair.generate().publicKey,
+      referralPoolAccount: Keypair.generate().publicKey,
+      poolMint: Keypair.generate().publicKey,
+      lamports: 99999,
+    };
+
+    const decoded = StakePoolInstruction.decodeDepositSol(StakePoolInstruction.depositSol(payload));
+
+    expect(decoded.stakePool).toEqual(payload.stakePool);
+    expect(decoded.withdrawAuthority).toEqual(payload.withdrawAuthority);
+    expect(decoded.reserveStake).toEqual(payload.reserveStake);
+    expect(decoded.fundingAccount).toEqual(payload.fundingAccount);
+    expect(decoded.destinationPoolAccount).toEqual(payload.destinationPoolAccount);
+    expect(decoded.managerFeeAccount).toEqual(payload.managerFeeAccount);
+    expect(decoded.referralPoolAccount).toEqual(payload.referralPoolAccount);
+    expect(decoded.poolMint).toEqual(payload.poolMint);
+    expect(decoded.lamports).toEqual(payload.lamports);
+    expect(decoded.depositAuthority).toBeUndefined();
+
+    const depositAuthority = Keypair.generate().publicKey;
+    const decodedWithAuthority = StakePoolInstruction.decodeDepositSol(
+      StakePoolInstruction.depositSol({ ...payload, depositAuthority }),
+    );
+
+    expect(decodedWithAuthority.depositAuthority).toEqual(depositAuthority);
+    expect(decodedWithAuthority.withdrawAuthority).toEqual(payload.withdrawAuthority);
+    expect(decodedWithAuthority.lamports).toEqual(payload.lamports);
+  });
+
   describe('addValidatorToPool', () => {
     const validatorList = mockValidatorList();
     const decodedValidatorList = ValidatorListLayout.decode(validatorList.data);


### PR DESCRIPTION
## What

`StakePoolInstruction.decodeDepositSol` does not round-trip `StakePoolInstruction.depositSol`. It returns the wrong account for almost every field, and `lamports` comes back `undefined`.

## Why

Two issues:

1. The instruction data is destructured as `{ amount }`, but the `DepositSol` layout field is `lamports` (`BufferLayout.ns64('lamports')`, and `depositSol` encodes `{ lamports }`). So `amount` is always `undefined` and the returned `lamports` is `undefined`. The existing `depositSol` test already asserts `decodeData(...).lamports`, which confirms the field name.

2. The account indexes do not match what `depositSol` builds. `depositSol` lays out `[stakePool, withdrawAuthority, reserveStake, fundingAccount, destinationPoolAccount, managerFeeAccount, referralPoolAccount, poolMint, systemProgram, tokenProgram]` and appends the optional `depositAuthority` at the end. The decoder read `depositAuthority` from index 1 and shifted every following account by one, so it returned the wrong pubkeys.

## Change

- Read `lamports` from the decoded data.
- Map the accounts to the same order `depositSol` produces, and read the optional `depositAuthority` from the end only when it is present.
- Add a round-trip test that encodes with `depositSol` and decodes with `decodeDepositSol`, covering both the presence and absence of the deposit authority.

## Verification

Ran in `clients/js-legacy`: `pnpm test`, `pnpm lint`, `pnpm run build`, and `pnpm format` all pass.
