### PR TITLE
program: Move slippage check down during withdraw-stake

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2879,12 +2879,6 @@ impl Processor {
             return Err(StakePoolError::WithdrawalTooSmall.into());
         }
 
-        if let Some(minimum_lamports_out) = minimum_lamports_out {
-            if withdraw_lamports < minimum_lamports_out {
-                return Err(StakePoolError::ExceededSlippage.into());
-            }
-        }
-
         let split_from_rent = rent.minimum_balance(stake_split_from.data_len());
         let stake_minimum_delegation = stake::tools::get_minimum_delegation()?;
         let stake_state = try_from_slice_unchecked::<stake::state::StakeStateV2>(
@@ -3060,6 +3054,12 @@ impl Processor {
             }
             Some((validator_stake_info, withdraw_source))
         };
+
+        if let Some(minimum_lamports_out) = minimum_lamports_out {
+            if withdraw_lamports < minimum_lamports_out {
+                return Err(StakePoolError::ExceededSlippage.into());
+            }
+        }
 
         Self::token_burn(
             token_program_info.clone(),


### PR DESCRIPTION
#### Problem

The stake pool program allows users to withdraw whole stake accounts in certain situations. In those cases, the amount of lamports withdrawn gets truncated downt to the current amount of lamports in the account.

The program also allows users to specify slippage when withdrawing from the pool. The withdraw-stake instruction runs the slippage check before the withdrawal amount has been rounded down when withdrawing a stake account, potentially violating the slippage param set by the user.

#### Summary of changes

Move the slippage check down to after the withdraw amount has been changed.

Fixes #882