### PR TITLE
program: Allow mints with a freeze authority

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -784,10 +784,6 @@ impl Processor {
                 return Err(StakePoolError::WrongMintingAuthority.into());
             }
 
-            if pool_mint.base.freeze_authority.is_some() {
-                return Err(StakePoolError::InvalidMintFreezeAuthority.into());
-            }
-
             let extensions = pool_mint.get_extension_types()?;
             if extensions
                 .iter()

--- a/program/tests/initialize.rs
+++ b/program/tests/initialize.rs
@@ -418,7 +418,7 @@ async fn fail_with_wrong_mint_authority() {
 }
 
 #[tokio::test]
-async fn fail_with_freeze_authority() {
+async fn succeed_with_freeze_authority() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::default();
 
@@ -474,7 +474,7 @@ async fn fail_with_freeze_authority() {
     .await
     .unwrap();
 
-    let error = create_stake_pool(
+    create_stake_pool(
         &mut banks_client,
         &payer,
         &recent_blockhash,
@@ -497,17 +497,7 @@ async fn fail_with_freeze_authority() {
         stake_pool_accounts.max_validators,
     )
     .await
-    .err()
-    .unwrap()
     .unwrap();
-
-    assert_eq!(
-        error,
-        TransactionError::InstructionError(
-            2,
-            InstructionError::Custom(error::StakePoolError::InvalidMintFreezeAuthority as u32),
-        )
-    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### Problem

The stake pool program does not allow pool creators to provide a mint with a freeze authority. The logic was that we always wanted to allow users to get their tokens out of the pool.

However, this limitation is a bit too harsh. DeFi protocols, for example, don't restrict trading based on freeze authorities present in the mint.

#### Summary of changes

Allow mints with a freeze authority during pool creation.

cc @jacobcreech