### PR TITLE
CI: Allow toggling semver checks off

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -39,6 +39,14 @@ on:
         required: true
         type: boolean
         default: true
+      run-semver:
+        description: |
+          Run semver checks.
+          Only disable checks if you are sure of the semver impact of your change and have a good reason
+          to skip it.
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   set_env:
@@ -85,4 +93,5 @@ jobs:
       version: ${{ inputs.version }}
       create-release: ${{ inputs.create-release }}
       dry-run: ${{ inputs.dry-run }}
+      run-semver: ${{ inputs.run-semver }}
     secrets: inherit


### PR DESCRIPTION
#### Problem

We haven't published the v2.1.0 crate, but it has some breaking changes according to cargo semver-checks, making it not possible to publish without doing a breaking release.

#### Summary of changes

Keep things simple, and just allow disabling the semver checks step, like with other repos. The breaking changes are an addition to an enum and some internal function signatures.