### PR TITLE
program: Bump to v2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8209,7 +8209,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool"
-version = "2.0.3"
+version = "2.1.1"
 dependencies = [
  "agave-feature-set",
  "arrayref",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -26,7 +26,7 @@ solana-sdk = "4.0.0"
 solana-stake-interface = { version = "4", features = ["bincode"] }
 solana-system-interface = { version = "3", features = ["bincode"] }
 spl-associated-token-account-interface = "2.0.0"
-spl-stake-pool = { version = "=2.0.3", path = "../../program", features = [
+spl-stake-pool = { version = "=2.1.1", path = "../../program", features = [
   "no-entrypoint",
 ] }
 spl-token-interface = "3.0"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-stake-pool"
-version = "2.0.3"
+version = "2.1.1"
 description = "Solana Program Library Stake Pool"
 homepage = "https://www.solana-program.com/docs/stake-pool"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]


### PR DESCRIPTION
#### Problem

`spl-stake-pool` version 2.1.1 was published from a different branch, and the main branch still has the version at 2.0.3.

#### Summary of changes

Bump the version to 2.1.1 so that we can publish from here again.